### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/lucas-labs/kypi/security/code-scanning/1](https://github.com/lucas-labs/kypi/security/code-scanning/1)

The fix involves adding a `permissions` block to explicitly define the least privileges required for the workflow. Since the workflow primarily involves reading repository contents and uploading coverage/test results, the permissions can be limited to `contents: read` and any specific scopes required for uploading results, such as `actions: write`.

The addition of the `permissions` block can be applied at the root level of the workflow (affecting all jobs) or within the `test` job itself. To ensure clarity and prevent excessive permissions, the permissions block will be added at the root level with the least privileges necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
