### PR TITLE
fix: 🚑 trying to interpolate port number as if it was a path param

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -279,7 +279,6 @@ export function client<E extends EndpointGroup>({
           kyOptions?: KyOptions,
         ): ResponsePromise<any> => {
           const makeKyCall = async (): Promise<ResponsePromise<any>> => {
-            let url = baseUrl + endpoint.url
             let params: any = undefined
             let body: any = undefined
             let query: any = undefined
@@ -293,8 +292,7 @@ export function client<E extends EndpointGroup>({
               body = input
             }
 
-            url = interpolateUrl(url, params)
-
+            const url = baseUrl + interpolateUrl(endpoint.url, params)
             let kyopts: KyOptions = { method: endpoint.method, headers: {} }
 
             // auth header

--- a/tests/client.unit.test.ts
+++ b/tests/client.unit.test.ts
@@ -217,6 +217,16 @@ describe('client', () => {
     )
   })
 
+  it("doesn't try to interpolate params in baseUrls (could have a port number :8080)", async () => {
+    const endpoints = {
+      getById: get<undefined, { id: number; name: string }, { id: number }>(
+        '/foo/:id',
+      ),
+    }
+    const api = client({ baseUrl: 'http://example:8080/api', endpoints }) as any
+    await api.getById({ params: { id: 2 } })
+  })
+
   it('merges per-request KyOptions (headers, searchParams, etc)', async () => {
     const api = client({ baseUrl, endpoints }) as any
     await api.foo(


### PR DESCRIPTION
e.g., give: `http://example.com:8080/api/foo/:id`
it expects a path param :id, but also :8080